### PR TITLE
Add Jest test for submit form character limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "https://github.com/BlackrockDigital/startbootstrap-creative.git"
   },
+  "scripts": {
+    "test": "jest"
+  },
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
     "font-awesome": "4.7.0",
@@ -41,6 +44,8 @@
     "gulp-header": "1.8.9",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.1.0",
-    "gulp-uglify": "3.0.0"
+    "gulp-uglify": "3.0.0",
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/submit.test.js
+++ b/tests/submit.test.js
@@ -1,0 +1,37 @@
+const { JSDOM } = require('jsdom');
+const jquery = require('jquery');
+
+describe('submit.js', () => {
+  let dom;
+  let $;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!doctype html><html><body>
+      <textarea id="message"></textarea>
+      <span id="characterLeft"></span>
+      <button id="btnSubmit"></button>
+    </body></html>`, { runScripts: 'dangerously' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    $ = jquery(dom.window);
+    global.$ = $;
+    // load the script under test
+    require('../js/submit.js');
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    delete require.cache[require.resolve('../js/submit.js')];
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
+
+  test('disables submit button at 140 characters', () => {
+    const message = $('#message');
+    message.val('a'.repeat(140));
+    message.trigger('keydown');
+    expect($('#btnSubmit').hasClass('disabled')).toBe(true);
+    expect($('#characterLeft').text()).toBe('You have reached the limit');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and jsdom dev dependencies and test script
- add unit test to ensure submit button disables at 140 characters

## Testing
- `npm test` *(fails: jest not found, npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c09cc5110483339871b6d806faab13